### PR TITLE
Django 1.10 Compatibility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,11 +17,11 @@ Add to ``settings.py``::
         'external_urls',
     )
 
-Add to ``url.py``::
+Add to ``urls.py``::
 
-    urlpatterns = patterns('',
+    urlpatterns = [
         url(r'', include('external_urls.urls')),
-    )
+    ]
 
 
 Usage:

--- a/external_urls/urls.py
+++ b/external_urls/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from views import ExternalLinkView
 
-urlpatterns = patterns('',
+urlpatterns = [
     url(r'^goto/(?P<external_url>.+)$', ExternalLinkView.as_view(), name='external_link'),
-)
+]


### PR DESCRIPTION
Django 1.10 has depreciated url.patterns. It now expects an array. This takes care of url handling in the "new" way.
